### PR TITLE
[Feat] #5 델리게이트 프로토콜 정의

### DIFF
--- a/UCDAppleStore/UCDAppleStore/Views/Protocols.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/Protocols.swift
@@ -1,0 +1,36 @@
+//
+//  Protocols.swift
+//  UCDAppleStore
+//
+//  Created by Milou on 6/26/25.
+//
+
+import Foundation
+
+/// CategoryView에서 누른 카테고리 버튼을 MainViewController에 알립니다.
+protocol CategoryViewDelegate: AnyObject {
+    /// 사용자가 카테고리 버튼을 눌렀을 때 호출됩니다
+    ///- Parameter category: 선택된 카테고리 (iPhone, iPad, MacBook, Mac, Accessories)
+    func categoryViewDidSelectCategory(_ category: Category)
+}
+
+/// ProductView에서 카트에 담긴 상품을 MainViewController에 알립니다.
+protocol ProductViewDelegate: AnyObject {
+    /// 사용자가 상품의 장바구니 버튼을 탭했을 때 호출됩니다
+    /// - Parameter product: 장바구니에 추가할 상품 정보
+    func productViewDidTapAddToCart(_ product: Product)
+}
+
+/// CartCell에서 상품 수량 변경(+,-)을 MainViewController에 알립니다.
+/// CartView에서 취소를 MainViewController에 알립니다.
+protocol CartViewDelegate: AnyObject {
+    /// 사용자가 장바구니 아이템의 수량 증가 버튼(⊕)을 탭했을 때 호출됩니다
+    /// - Parameter product: 수량을 증가시킬 상품
+    func cartCellDidIncreaseQuantity(for product: Product)
+    /// 사용자가 장바구니 아이템의 수량 감소 버튼(⊖)을 탭했을 때 호출됩니다
+    /// - Parameter product: 수량을 감소시킬 상품 (0이 되면 장바구니에서 제거됨)
+    func cartCellDidDecreaseQuantity(for product: Product)
+    /// 사용자가 취소하기 버튼을 탭했을 때 호출됩니다
+    /// 장바구니의 모든 아이템이 제거됩니다
+    func cartViewDidTapCancel()
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #5 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

커스텀 뷰들이 MainViewController와 통신할 수 있는 델리게이트 프로토콜을 정의했습니다
- CategoryViewDelegate: 카테고리 선택 알림
- ProductViewDelegate: 장바구니 담기 알림  
- CartViewDelegate: 수량 조절 및 취소 알림

<br>


## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
### ↪️ 사용자 액션 → 뷰 → 뷰컨트롤러 → 뷰모델 흐름 정리
- 이후에 각 뷰의 버튼 액션에서 델리게이트 메서드 호출하면,
- MainViewController에서 각 델리게이트 프로토콜을 채택 -> 해당 뷰모델의 로직 함수 호출하는 메서드를 구현합니다

<br>
