### PR TITLE
[Chore]#6 장바구니 뷰 출력 구현

### DIFF
--- a/UCDAppleStore/UCDAppleStore/Models/Cart.swift
+++ b/UCDAppleStore/UCDAppleStore/Models/Cart.swift
@@ -3,11 +3,11 @@ import Foundation
 
 struct Cart: Hashable {
     private(set) var items: [CartItem] = []
-    
+
     var totalPrice: Int {
-        return items.reduce(into: 0) { $0 + $1.totalPrice }
+        return items.reduce(0) { $0 + $1.totalPrice }
     }
-    
+
     var totalCount: Int {
         return items.reduce(0) { $0 + $1.quantity }
     }

--- a/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
@@ -2,37 +2,51 @@
 import Foundation
 
 final class CartViewModel {
-    // 테스트용 하드 코딩 데이터
-    private(set) var testCart: [CartItem] = [
-        CartItem(
-            product: Product(
-                id: 1,
-                name: "iPhone 16",
-                category: .iPhone,
-                price: 1_250_000,
-                imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+    private(set) var testCart: Cart
+
+    init() {
+        // 하드코딩된 테스트 데이터
+        let testCartItems: [CartItem] = [
+            CartItem(
+                product: Product(
+                    id: 1,
+                    name: "iPhone 16",
+                    category: .iPhone,
+                    price: 1_250_000,
+                    imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+                ),
+                quantity: 1
             ),
-            quantity: 1
-        ),
-        CartItem(
-            product: Product(
-                id: 2,
-                name: "iPhone 16 Plus",
-                category: .iPhone,
-                price: 1_350_000,
-                imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+            CartItem(
+                product: Product(
+                    id: 2,
+                    name: "iPhone 16 Plus",
+                    category: .iPhone,
+                    price: 1_350_000,
+                    imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+                ),
+                quantity: 2
             ),
-            quantity: 2
-        ),
-        CartItem(
-            product: Product(
-                id: 6,
-                name: "iPad A16",
-                category: .iPad,
-                price: 529_000,
-                imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+            CartItem(
+                product: Product(
+                    id: 6,
+                    name: "iPad A16",
+                    category: .iPad,
+                    price: 529_000,
+                    imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+                ),
+                quantity: 1
             ),
-            quantity: 1
-        ),
-    ]
+        ]
+
+        testCart = Cart(items: testCartItems)
+    }
+
+    var totalPriceText: String {
+        "\(testCart.totalPrice)원"
+    }
+
+    var purchaseButtonTitle: String {
+        "총 \(testCart.totalCount)개 결제하기"
+    }
 }

--- a/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
@@ -1,0 +1,38 @@
+
+import Foundation
+
+final class CartViewModel {
+    // 테스트용 하드 코딩 데이터
+    private(set) var testCart: [CartItem] = [
+        CartItem(
+            product: Product(
+                id: 1,
+                name: "iPhone 16",
+                category: .iPhone,
+                price: 1_250_000,
+                imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+            ),
+            quantity: 1
+        ),
+        CartItem(
+            product: Product(
+                id: 2,
+                name: "iPhone 16 Plus",
+                category: .iPhone,
+                price: 1_350_000,
+                imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+            ),
+            quantity: 2
+        ),
+        CartItem(
+            product: Product(
+                id: 6,
+                name: "iPad A16",
+                category: .iPad,
+                price: 529_000,
+                imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+            ),
+            quantity: 1
+        ),
+    ]
+}

--- a/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
@@ -2,17 +2,52 @@
 import UIKit
 
 import SnapKit
+import Then
 
 final class CartItemCell: UICollectionViewCell {
+    
     static let reuseIdentifier = "CartItemCell"
 
-    private let nameLabel = UILabel()
-    private let quantityLabel = UILabel()
-    private let totalPriceLabel = UILabel()
+    private let nameLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 16, weight: .medium)
+    }
+
+    private let unitPriceLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 14)
+        $0.textAlignment = .right
+    }
+
+    private let minusButton = UIButton().then {
+        $0.setTitle("⊖", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+    }
+
+    private let quantityLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 14)
+        $0.textAlignment = .center
+    }
+
+    private let plusButton = UIButton().then {
+        $0.setTitle("⊕", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+    }
+
+    private let totalPriceLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 15, weight: .semibold)
+        $0.textAlignment = .right
+    }
+
+    private let separatorView = UIView().then {
+        $0.backgroundColor = .systemGray4
+    }
+    
+    private var cellIndex: Int? // 셀의 인덱스
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 12
     }
 
     @available(*, unavailable)
@@ -20,28 +55,64 @@ final class CartItemCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(with item: CartItem) {
+    func configure(with item: CartItem, index: Int) {
         nameLabel.text = item.product.name
-        quantityLabel.text = "수량: \(item.quantity)"
+        unitPriceLabel.text = "\(item.product.price)원"
+        quantityLabel.text = "\(item.quantity)"
         totalPriceLabel.text = "총액: \(item.totalPrice)원"
+        cellIndex = index
     }
 
     private func setupUI() {
-        contentView.addSubview(nameLabel)
-        contentView.addSubview(quantityLabel)
-        contentView.addSubview(totalPriceLabel)
+        let itemList = [
+            nameLabel,
+            unitPriceLabel,
+            minusButton,
+            quantityLabel,
+            plusButton,
+            totalPriceLabel,
+            separatorView,
+        ]
+
+        for item in itemList {
+            contentView.addSubview(item)
+        }
 
         nameLabel.snp.makeConstraints {
-            $0.top.leading.equalToSuperview().inset(8)
+            $0.top.equalToSuperview().offset(8)
+            $0.leading.equalToSuperview().offset(12)
+        }
+
+        unitPriceLabel.snp.makeConstraints {
+            $0.centerY.equalTo(nameLabel)
+            $0.trailing.equalToSuperview().inset(12)
+        }
+
+        separatorView.snp.makeConstraints {
+            $0.top.equalTo(nameLabel.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview().inset(12)
+            $0.height.equalTo(1)
+        }
+
+        minusButton.snp.makeConstraints {
+            $0.top.equalTo(separatorView.snp.bottom).offset(12)
+            $0.leading.equalToSuperview().offset(12)
+            $0.width.height.equalTo(24)
         }
 
         quantityLabel.snp.makeConstraints {
-            $0.top.equalTo(nameLabel.snp.bottom).offset(4)
-            $0.leading.equalToSuperview().inset(8)
+            $0.centerY.equalTo(minusButton)
+            $0.leading.equalTo(minusButton.snp.trailing).offset(8)
+        }
+
+        plusButton.snp.makeConstraints {
+            $0.centerY.equalTo(minusButton)
+            $0.leading.equalTo(quantityLabel.snp.trailing).offset(8)
+            $0.width.height.equalTo(24)
         }
 
         totalPriceLabel.snp.makeConstraints {
-            $0.bottom.trailing.equalToSuperview().inset(8)
+            $0.bottom.trailing.equalToSuperview().inset(12)
         }
     }
 }

--- a/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
@@ -1,0 +1,47 @@
+
+import UIKit
+
+import SnapKit
+
+final class CartItemCell: UICollectionViewCell {
+    static let reuseIdentifier = "CartItemCell"
+
+    private let nameLabel = UILabel()
+    private let quantityLabel = UILabel()
+    private let totalPriceLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with item: CartItem) {
+        nameLabel.text = item.product.name
+        quantityLabel.text = "수량: \(item.quantity)"
+        totalPriceLabel.text = "총액: \(item.totalPrice)원"
+    }
+
+    private func setupUI() {
+        contentView.addSubview(nameLabel)
+        contentView.addSubview(quantityLabel)
+        contentView.addSubview(totalPriceLabel)
+
+        nameLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(8)
+        }
+
+        quantityLabel.snp.makeConstraints {
+            $0.top.equalTo(nameLabel.snp.bottom).offset(4)
+            $0.leading.equalToSuperview().inset(8)
+        }
+
+        totalPriceLabel.snp.makeConstraints {
+            $0.bottom.trailing.equalToSuperview().inset(8)
+        }
+    }
+}

--- a/UCDAppleStore/UCDAppleStore/Views/CartView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartView.swift
@@ -1,0 +1,45 @@
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class CartView: UIView {
+    
+    let totalPriceLabel = UILabel().then {
+        $0.text = "$ 1200.00"
+    }
+    
+    let cancelButton = UIButton().then {
+        $0.setTitle("취소하기", for: .normal)
+    }
+    
+    let purchaseButton = UIButton().then {
+        $0.setTitle( "구매하기", for: .normal)
+    }
+    
+    let cartCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout()
+    ).then{
+        let layout = UICollectionViewFlowLayout() // 수직 스크롤형태
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 16 // 셀 간 여백
+        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize // 셀 높이 자동조절
+        $0.collectionViewLayout = layout
+        $0.backgroundColor = .clear
+    }
+        
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupView() {
+        
+    }
+}

--- a/UCDAppleStore/UCDAppleStore/Views/CartView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartView.swift
@@ -5,10 +5,12 @@ import SnapKit
 import Then
 
 class CartView: UIView {
-    var cartViewModel = CartViewModel()
+    private let cartViewModel = CartViewModel()
 
     let totalPriceLabel = UILabel().then {
-        $0.text = "Total Price : $ 1200.00"
+        $0.font = .boldSystemFont(ofSize: 16)
+        $0.textColor = .black
+        $0.textAlignment = .right
     }
 
     let cancelButton = UIButton().then {
@@ -18,7 +20,6 @@ class CartView: UIView {
     }
 
     let purchaseButton = UIButton().then {
-        $0.setTitle("구매하기", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.backgroundColor = .systemBlue
     }
@@ -30,7 +31,7 @@ class CartView: UIView {
         let layout = UICollectionViewFlowLayout() // 수직 스크롤형태
         layout.scrollDirection = .vertical
         layout.minimumLineSpacing = 16 // 셀 간 여백
-        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 32, height: 80)
+        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 32, height: 80) // 임시 아이템 사이즈 지정
         $0.collectionViewLayout = layout
         $0.backgroundColor = .clear
     }
@@ -40,6 +41,9 @@ class CartView: UIView {
         cartCollectionView.register(CartItemCell.self, forCellWithReuseIdentifier: CartItemCell.reuseIdentifier)
         cartCollectionView.dataSource = self
         setupView()
+        setupView()
+        setupTotalPriceText()
+        setupPurchaseButtonTitle()
     }
 
     @available(*, unavailable)
@@ -70,16 +74,21 @@ class CartView: UIView {
             $0.leading.trailing.bottom.equalToSuperview().inset(16)
         }
     }
-}
 
-// 컬렉션 뷰 프로토콜 추가
-extension CartView: UICollectionViewDataSource {
-    // 셀을 몇개 담을 것인가
-    func collectionView(_: UICollectionView, numberOfItemsInSection _: Int) -> Int {
-        return cartViewModel.testCart.count
+    func setupPurchaseButtonTitle() {
+        purchaseButton.setTitle(cartViewModel.purchaseButtonTitle, for: .normal)
     }
 
-    // 셀은 어떻게 담을 것인가
+    func setupTotalPriceText() {
+        totalPriceLabel.text = cartViewModel.totalPriceText
+    }
+}
+
+extension CartView: UICollectionViewDataSource {
+    func collectionView(_: UICollectionView, numberOfItemsInSection _: Int) -> Int {
+        return cartViewModel.testCart.items.count
+    }
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: "CartItemCell",
@@ -88,8 +97,8 @@ extension CartView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
 
-        let item = cartViewModel.testCart[indexPath.item]
-        cell.configure(with: item)
+        let item = cartViewModel.testCart.items[indexPath.item]
+        cell.configure(with: item, index: indexPath.item)
         return cell
     }
 }

--- a/UCDAppleStore/UCDAppleStore/Views/CartView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartView.swift
@@ -4,42 +4,92 @@ import UIKit
 import SnapKit
 import Then
 
-final class CartView: UIView {
-    
+class CartView: UIView {
+    var cartViewModel = CartViewModel()
+
     let totalPriceLabel = UILabel().then {
-        $0.text = "$ 1200.00"
+        $0.text = "Total Price : $ 1200.00"
     }
-    
+
     let cancelButton = UIButton().then {
         $0.setTitle("취소하기", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .systemGray4
     }
-    
+
     let purchaseButton = UIButton().then {
-        $0.setTitle( "구매하기", for: .normal)
+        $0.setTitle("구매하기", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .systemBlue
     }
-    
+
     let cartCollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: UICollectionViewFlowLayout()
-    ).then{
+    ).then {
         let layout = UICollectionViewFlowLayout() // 수직 스크롤형태
         layout.scrollDirection = .vertical
         layout.minimumLineSpacing = 16 // 셀 간 여백
-        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize // 셀 높이 자동조절
+        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 32, height: 80)
         $0.collectionViewLayout = layout
         $0.backgroundColor = .clear
     }
-        
+
     override init(frame: CGRect) {
         super.init(frame: frame)
+        cartCollectionView.register(CartItemCell.self, forCellWithReuseIdentifier: CartItemCell.reuseIdentifier)
+        cartCollectionView.dataSource = self
         setupView()
     }
-    
-    required init?(coder: NSCoder) {
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func setupView() {
-        
+        addSubview(totalPriceLabel)
+        addSubview(cancelButton)
+        addSubview(purchaseButton)
+        addSubview(cartCollectionView)
+
+        totalPriceLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(16)
+        }
+        cancelButton.snp.makeConstraints {
+            $0.top.equalTo(totalPriceLabel.snp.bottom).offset(8)
+            $0.trailing.equalTo(self.snp.centerX).offset(-32)
+        }
+        purchaseButton.snp.makeConstraints {
+            $0.top.equalTo(totalPriceLabel.snp.bottom).offset(8)
+            $0.leading.equalTo(self.snp.centerX).offset(32)
+        }
+        cartCollectionView.snp.makeConstraints {
+            $0.top.equalTo(purchaseButton.snp.bottom).offset(8)
+            $0.leading.trailing.bottom.equalToSuperview().inset(16)
+        }
+    }
+}
+
+// 컬렉션 뷰 프로토콜 추가
+extension CartView: UICollectionViewDataSource {
+    // 셀을 몇개 담을 것인가
+    func collectionView(_: UICollectionView, numberOfItemsInSection _: Int) -> Int {
+        return cartViewModel.testCart.count
+    }
+
+    // 셀은 어떻게 담을 것인가
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: "CartItemCell",
+            for: indexPath
+        ) as? CartItemCell else {
+            return UICollectionViewCell()
+        }
+
+        let item = cartViewModel.testCart[indexPath.item]
+        cell.configure(with: item)
+        return cell
     }
 }


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #6 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

CartView : 장바구니에서 쓸 뷰
CartViewModel : 앞으로 사용할 뷰모델
CartItemCell : 컬렉션 뷰에서 쓰일 셀 뷰

뷰 모델에 하드코딩으로 목업 데이터를 만들고
레이아웃은 임의 값으로 와이어프레임과 비슷하게 출력을 구현 했습니다.
<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
  <img width="300" alt="" src="https://github.com/user-attachments/assets/910e3a80-7e80-4cfd-b6cf-51d13cdaef3a">  
<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
데이터 리소스 Cart.swift의 totalPrice 계산식을 수정했습니다.

<br>
