### PR TITLE
Chore/#30 장바구니 뷰 UI수정

### DIFF
--- a/UCDAppleStore/UCDAppleStore/Utils/Extensions/Int+Formatting.swift
+++ b/UCDAppleStore/UCDAppleStore/Utils/Extensions/Int+Formatting.swift
@@ -1,0 +1,11 @@
+
+import Foundation
+
+// 1,000단위 콤마용 Int 확장
+extension Int {
+    var formattedWithComma: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
+    }
+}

--- a/UCDAppleStore/UCDAppleStore/ViewController/ViewController.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewController/ViewController.swift
@@ -1,26 +1,108 @@
+
 import UIKit
 
-class ViewController: UIViewController {
-    private let productListView = ProductListView()
-    private let viewModel = ProductViewModel()
+import SnapKit
 
-    override func loadView() {
-        view = productListView
+class ViewController: UIViewController, CartViewDelegate {
+    private let cartView = CartView()
+
+    private let addButton = UIButton().then {
+        $0.setTitle("추가 테스트", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .systemGreen
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Apple Products"
-        bindViewModel()
-        viewModel.fetchProducts()
+        // Do any additional setup after loading the view.
+        view.backgroundColor = .systemGray6
+
+        // 카트뷰 테스트용
+        view.addSubview(cartView)
+
+        cartView.delegate = self
+
+        cartView.snp.makeConstraints {
+            $0.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        // 추가버튼 테스트용
+//        view.addSubview(addButton)
+
+//        addButton.snp.makeConstraints {
+//            $0.leading.trailing.equalToSuperview().inset(24)
+//            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(80)
+//            $0.height.equalTo(48)
+//        }
+
+        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
     }
 
-    private func bindViewModel() {
-        viewModel.onDataUpdated = { [weak self] in
-            guard let self else { return }
-            DispatchQueue.main.async {
-                self.productListView.reload(products: self.viewModel.products)
-            }
+    func cartCellDidIncreaseQuantity(for product: Product) {
+        print("VC: + 버튼 눌림 - \(product.name)")
+        cartView.cartViewModel.increaseQuantiy(for: product)
+        cartView.reloadCartUI()
+    }
+
+    func cartCellDidDecreaseQuantity(for product: Product) {
+        print("VC: - 버튼 눌림 - \(product.name)")
+        cartView.cartViewModel.decreaseQuantiy(for: product)
+        cartView.reloadCartUI()
+    }
+
+    func cartViewDidTapCancel() {
+        print("VC: 초기화 버튼 눌림")
+        cartView.cartViewModel.onAlertTriggered?(.confirmClearCart)
+    }
+
+    @objc private func addButtonTapped() {
+        let product = Product(
+            id: 11,
+            name: "iPad Pro M5 13〃",
+            category: .ipad,
+            price: 2_099_000,
+            imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
+        )
+        let item = CartItem(product: product, quantity: 1)
+        cartView.cartViewModel.addCartItem(item)
+        cartView.reloadCartUI()
+    }
+
+    func cartViewShouldShowAlert(_ alertType: CartAlertType) {
+        var message = ""
+        switch alertType {
+        case .quantityLimitExceeded:
+            message = "최대 수량은 10개입니다."
+
+            let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            present(alert, animated: true)
+
+        case let .confirmRemoveItem(product):
+            let alert = UIAlertController(
+                title: "알림",
+                message: "\"\(product.name)\"을 삭제하시겠습니까?",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+            alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+                self?.cartView.cartViewModel.removeItem(for: product)
+                self?.cartView.reloadCartUI()
+            })
+            present(alert, animated: true)
+
+        case .confirmClearCart:
+            let alert = UIAlertController(
+                title: "알림",
+                message: "장바구니를 비우시겠습니까?",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+            alert.addAction(UIAlertAction(title: "확인", style: .destructive) { [weak self] _ in
+                self?.cartView.cartViewModel.clearCart()
+                self?.cartView.reloadCartUI()
+            })
+            present(alert, animated: true)
         }
     }
 }

--- a/UCDAppleStore/UCDAppleStore/ViewController/ViewController.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewController/ViewController.swift
@@ -1,108 +1,27 @@
 
 import UIKit
 
-import SnapKit
+class ViewController: UIViewController {
+    private let productListView = ProductListView()
+    private let viewModel = ProductViewModel()
 
-class ViewController: UIViewController, CartViewDelegate {
-    private let cartView = CartView()
-
-    private let addButton = UIButton().then {
-        $0.setTitle("추가 테스트", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .systemGreen
+    override func loadView() {
+        view = productListView
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
-        view.backgroundColor = .systemGray6
-
-        // 카트뷰 테스트용
-        view.addSubview(cartView)
-
-        cartView.delegate = self
-
-        cartView.snp.makeConstraints {
-            $0.edges.equalTo(view.safeAreaLayoutGuide)
-        }
-
-        // 추가버튼 테스트용
-//        view.addSubview(addButton)
-
-//        addButton.snp.makeConstraints {
-//            $0.leading.trailing.equalToSuperview().inset(24)
-//            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(80)
-//            $0.height.equalTo(48)
-//        }
-
-        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+        title = "Apple Products"
+        bindViewModel()
+        viewModel.fetchProducts()
     }
 
-    func cartCellDidIncreaseQuantity(for product: Product) {
-        print("VC: + 버튼 눌림 - \(product.name)")
-        cartView.cartViewModel.increaseQuantiy(for: product)
-        cartView.reloadCartUI()
-    }
-
-    func cartCellDidDecreaseQuantity(for product: Product) {
-        print("VC: - 버튼 눌림 - \(product.name)")
-        cartView.cartViewModel.decreaseQuantiy(for: product)
-        cartView.reloadCartUI()
-    }
-
-    func cartViewDidTapCancel() {
-        print("VC: 초기화 버튼 눌림")
-        cartView.cartViewModel.onAlertTriggered?(.confirmClearCart)
-    }
-
-    @objc private func addButtonTapped() {
-        let product = Product(
-            id: 11,
-            name: "iPad Pro M5 13〃",
-            category: .ipad,
-            price: 2_099_000,
-            imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
-        )
-        let item = CartItem(product: product, quantity: 1)
-        cartView.cartViewModel.addCartItem(item)
-        cartView.reloadCartUI()
-    }
-
-    func cartViewShouldShowAlert(_ alertType: CartAlertType) {
-        var message = ""
-        switch alertType {
-        case .quantityLimitExceeded:
-            message = "최대 수량은 10개입니다."
-
-            let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "확인", style: .default))
-            present(alert, animated: true)
-
-        case let .confirmRemoveItem(product):
-            let alert = UIAlertController(
-                title: "알림",
-                message: "\"\(product.name)\"을 삭제하시겠습니까?",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "취소", style: .cancel))
-            alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
-                self?.cartView.cartViewModel.removeItem(for: product)
-                self?.cartView.reloadCartUI()
-            })
-            present(alert, animated: true)
-
-        case .confirmClearCart:
-            let alert = UIAlertController(
-                title: "알림",
-                message: "장바구니를 비우시겠습니까?",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "취소", style: .cancel))
-            alert.addAction(UIAlertAction(title: "확인", style: .destructive) { [weak self] _ in
-                self?.cartView.cartViewModel.clearCart()
-                self?.cartView.reloadCartUI()
-            })
-            present(alert, animated: true)
+    private func bindViewModel() {
+        viewModel.onDataUpdated = { [weak self] in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                self.productListView.reload(products: self.viewModel.products)
+            }
         }
     }
 }

--- a/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
@@ -61,7 +61,7 @@ final class CartViewModel {
     // MARK: Properties
 
     var totalPriceText: String {
-        "\(cartItems.reduce(0) { $0 + $1.totalPrice })원"
+        "총액 : \(cartItems.reduce(0) { $0 + $1.totalPrice }.formattedWithComma)원"
     }
 
     var purchaseButtonTitle: String {

--- a/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewModels/CartViewModel.swift
@@ -47,10 +47,10 @@ final class CartViewModel {
             ),
             CartItem(
                 product: Product(
-                    id: 12,
-                    name: "MacBook Air M4 13〃 16GB 256GB",
-                    category: .ipad,
-                    price: 1_590_000,
+                    id: 29,
+                    name: "PopSockets MagSafe Grip (iPhone)-스트로베리",
+                    category: .accessories,
+                    price: 59000,
                     imageURL: URL(string: "https://store.storeimages.cdn-apple.com/...")!
                 ),
                 quantity: 1

--- a/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
@@ -127,9 +127,9 @@ final class CartItemCell: UICollectionViewCell {
 
     func configure(with item: CartItem) {
         nameLabel.text = item.product.name
-        unitPriceLabel.text = "\(item.product.price)원"
+        unitPriceLabel.text = "\(item.product.price.formattedWithComma)원"
         quantityLabel.text = "\(item.quantity)"
-        totalPriceLabel.text = "총액: \(item.totalPrice)원"
+        totalPriceLabel.text = "\(item.totalPrice.formattedWithComma)원"
     }
 
     // MARK: Actions

--- a/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartItemCell.swift
@@ -16,40 +16,57 @@ final class CartItemCell: UICollectionViewCell {
 
     // MARK: UI Components
 
+    // 상단 스택뷰
+    private let topRowStackView = UIStackView().then {
+        $0.axis = .horizontal // 수평 정렬
+        $0.spacing = 8 // name과 price 사이 여백
+        $0.alignment = .center // 수직 중앙 정렬
+        $0.distribution = .fill // 너비는 내용물에 맞게 분배
+    }
+
     private let nameLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 16, weight: .medium)
+        $0.textColor = UIColor(named: "TextColor")
     }
 
     private let unitPriceLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 14)
         $0.textAlignment = .right
+        $0.textColor = UIColor(named: "TextColor")
+    }
+
+    // 하단 스택뷰
+    private let bottomRowStackView = UIStackView().then {
+        $0.axis = .horizontal // 수평 정렬
+        $0.spacing = 8 // name과 price 사이 여백
+        $0.alignment = .center // 수직 중앙 정렬
     }
 
     private let minusButton = UIButton().then {
-        let configuration = UIImage.SymbolConfiguration(pointSize: 30)
+        let configuration = UIImage.SymbolConfiguration(pointSize: 24)
         $0.setImage(UIImage(systemName: "minus.circle", withConfiguration: configuration), for: .normal)
-        $0.tintColor = .black
+        $0.tintColor = UIColor(named: "TextColor")
     }
 
     private let quantityLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 16)
+        $0.font = .systemFont(ofSize: 18)
         $0.textAlignment = .center
+        $0.textColor = UIColor(named: "TextColor")
     }
 
     private let plusButton = UIButton().then {
-        let configuration = UIImage.SymbolConfiguration(pointSize: 30)
+        let configuration = UIImage.SymbolConfiguration(pointSize: 24)
         $0.setImage(UIImage(systemName: "plus.circle", withConfiguration: configuration), for: .normal)
-        $0.tintColor = .black
+        $0.tintColor = UIColor(named: "TextColor")
     }
 
     private let totalPriceLabel = UILabel().then {
-        $0.font = .systemFont(ofSize: 15, weight: .semibold)
+        $0.font = .systemFont(ofSize: 16, weight: .semibold)
         $0.textAlignment = .right
     }
 
     private let separatorView = UIView().then {
-        $0.backgroundColor = .systemGray4
-        $0.tintColor = .black
+        $0.backgroundColor = UIColor(named: "TextColor")
     }
 
     // MARK: Initailizers
@@ -69,59 +86,57 @@ final class CartItemCell: UICollectionViewCell {
     // MARK: Setup Methods
 
     private func setupUI() {
-        contentView.backgroundColor = .white
+        contentView.backgroundColor = UIColor(named: "CartCellColor")
         contentView.layer.cornerRadius = 12
 
-        let itemList = [
-            nameLabel,
-            unitPriceLabel,
-            minusButton,
-            quantityLabel,
-            plusButton,
-            totalPriceLabel,
-            separatorView,
-        ]
+        // 상단 스택뷰
+        topRowStackView.addArrangedSubview(nameLabel)
+        topRowStackView.addArrangedSubview(unitPriceLabel)
+        contentView.addSubview(topRowStackView)
 
-        for item in itemList {
-            contentView.addSubview(item)
-        }
+        // 길이가 충돌할만큼 긴 경우를 위해 hugging compression 설정
+        nameLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-        nameLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(8)
-            $0.leading.equalToSuperview().offset(12)
-        }
+        unitPriceLabel.setContentHuggingPriority(.required, for: .horizontal)
+        unitPriceLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-        unitPriceLabel.snp.makeConstraints {
-            $0.centerY.equalTo(nameLabel)
-            $0.trailing.equalToSuperview().inset(12)
+        contentView.addSubview(separatorView)
+
+        // 하단 스택뷰
+        bottomRowStackView.addArrangedSubview(minusButton)
+        bottomRowStackView.addArrangedSubview(quantityLabel)
+        bottomRowStackView.addArrangedSubview(plusButton)
+        contentView.addSubview(bottomRowStackView)
+
+        contentView.addSubview(totalPriceLabel)
+
+        // 오토 레이아웃 설정
+
+        topRowStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.leading.trailing.equalToSuperview().inset(12)
         }
 
         separatorView.snp.makeConstraints {
-            $0.top.equalTo(nameLabel.snp.bottom).offset(8)
+            $0.top.equalTo(topRowStackView.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(12)
             $0.height.equalTo(1)
         }
 
-        minusButton.snp.makeConstraints {
+        bottomRowStackView.snp.makeConstraints {
             $0.top.equalTo(separatorView.snp.bottom).offset(12)
             $0.leading.equalToSuperview().offset(12)
-            $0.width.height.equalTo(24)
+            $0.bottom.equalToSuperview().inset(12).priority(.low)
         }
 
-        quantityLabel.snp.makeConstraints {
-            $0.centerY.equalTo(minusButton)
-            $0.leading.equalTo(minusButton.snp.trailing).offset(8)
-            $0.width.equalTo(28)
-        }
-
-        plusButton.snp.makeConstraints {
-            $0.centerY.equalTo(minusButton)
-            $0.leading.equalTo(quantityLabel.snp.trailing).offset(8)
-            $0.width.height.equalTo(24)
-        }
+        minusButton.snp.makeConstraints { $0.size.equalTo(40) }
+        plusButton.snp.makeConstraints { $0.size.equalTo(40) }
+        quantityLabel.snp.makeConstraints { $0.width.equalTo(32) }
 
         totalPriceLabel.snp.makeConstraints {
-            $0.bottom.trailing.equalToSuperview().inset(12)
+            $0.centerY.equalTo(bottomRowStackView)
+            $0.trailing.equalToSuperview().inset(12)
         }
     }
 

--- a/UCDAppleStore/UCDAppleStore/Views/CartView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartView.swift
@@ -24,16 +24,9 @@ class CartView: UIView {
         $0.textAlignment = .right
     }
 
-    let cancelButton = UIButton().then {
-        $0.setTitle("초기화", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .systemGray4
-    }
+    let resetButton = UCDButton(style: .reset)
 
-    let purchaseButton = UIButton().then {
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .systemBlue
-    }
+    let purchaseButton = UCDButton(style: .checkout)
 
     let cartCollectionView = UICollectionView(
         frame: .zero,
@@ -56,7 +49,8 @@ class CartView: UIView {
         setupView()
         updateTotalPriceText()
         updatePurchaseButtonTitle()
-        cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
+        resetButton.setTitle = "초기화"
+        resetButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
         purchaseButton.addTarget(self, action: #selector(purchaseButtonTapped), for: .touchUpInside)
         cartViewModel.onAlertTriggered = { [weak self] alertType in
             self?.delegate?.cartViewShouldShowAlert(alertType)
@@ -72,7 +66,7 @@ class CartView: UIView {
 
     func setupView() {
         addSubview(totalPriceLabel)
-        addSubview(cancelButton)
+        addSubview(resetButton)
         addSubview(purchaseButton)
         addSubview(cartCollectionView)
 
@@ -83,7 +77,7 @@ class CartView: UIView {
         }
 
         // 2. 하단 버튼들: 아래에 고정
-        cancelButton.snp.makeConstraints {
+        resetButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(16)
             $0.bottom.equalToSuperview().inset(16)
             $0.trailing.equalTo(purchaseButton.snp.leading).offset(-8)
@@ -101,14 +95,14 @@ class CartView: UIView {
         cartCollectionView.snp.makeConstraints {
             $0.top.equalTo(totalPriceLabel.snp.bottom).offset(8)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalTo(cancelButton.snp.top).offset(-12)
+            $0.bottom.equalTo(resetButton.snp.top).offset(-12)
         }
     }
 
     // MARK: Methods
 
     func updatePurchaseButtonTitle() {
-        purchaseButton.setTitle(cartViewModel.purchaseButtonTitle, for: .normal)
+        purchaseButton.setTitle = cartViewModel.purchaseButtonTitle
         updatePurchaseButtonState()
     }
 
@@ -140,8 +134,7 @@ class CartView: UIView {
     func updatePurchaseButtonState() {
         let isEnabled = cartViewModel.isPurchaseAvailable
         purchaseButton.isEnabled = isEnabled
-        purchaseButton.backgroundColor = isEnabled ? .systemBlue : .systemGray3
-        purchaseButton.alpha = isEnabled ? 1.0 : 0.5
+        purchaseButton.alpha = isEnabled ? 1.0 : 0.5 // 투명도 조절
     }
 }
 

--- a/UCDAppleStore/UCDAppleStore/Views/CartView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/CartView.swift
@@ -19,8 +19,8 @@ class CartView: UIView {
     // MARK: UI Components
 
     let totalPriceLabel = UILabel().then {
-        $0.font = .boldSystemFont(ofSize: 16)
-        $0.textColor = .black
+        $0.font = .boldSystemFont(ofSize: 20)
+        $0.textColor = UIColor(named: "TextColor")
         $0.textAlignment = .right
     }
 
@@ -28,6 +28,7 @@ class CartView: UIView {
 
     let purchaseButton = UCDButton(style: .checkout)
 
+    // TODO: UICollectionViewCompositionalLayout -> ListLayout으로 변경
     let cartCollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: UICollectionViewFlowLayout()
@@ -35,7 +36,6 @@ class CartView: UIView {
         let layout = UICollectionViewFlowLayout() // 수직 스크롤형태
         layout.scrollDirection = .vertical
         layout.minimumLineSpacing = 16 // 셀 간 여백
-        layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 32, height: 80) // 임시 아이템 사이즈 지정
         $0.collectionViewLayout = layout
         $0.backgroundColor = .clear
     }
@@ -46,6 +46,7 @@ class CartView: UIView {
         super.init(frame: frame)
         cartCollectionView.register(CartItemCell.self, forCellWithReuseIdentifier: CartItemCell.reuseIdentifier)
         cartCollectionView.dataSource = self
+        cartCollectionView.delegate = self
         setupView()
         updateTotalPriceText()
         updatePurchaseButtonTitle()
@@ -164,5 +165,14 @@ extension CartView: UICollectionViewDataSource {
             self?.delegate?.cartCellDidDecreaseQuantity(for: item.product)
         }
         return cell
+    }
+}
+
+// TODO: UICollectionViewCompositionalLayout -> ListLayout 으로 변경시에는 삭제
+extension CartView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt _: IndexPath) -> CGSize {
+        return CGSize(
+            width: collectionView.frame.width, height: 102
+        )
     }
 }


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #30 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

1. 장바구니가 비었을 때 버튼 비활성화 및 alpha값 조정으로 반투명하게 시각적으로 처리
2. 숫자가 1,000단위 콤마로 보이게 포맷팅
3. [+] [-] 버튼 확대와 이에 따른 오토 레이아웃 수정
4. 폰트컬러 틴트컬러를 다크모드 컬러에셋에 맞추어 다크모드 대응
<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

  <img width="300" alt="" src="https://github.com/user-attachments/assets/3c3c8460-5360-417e-be03-6593e24a9352">  
  <img width="300" alt="" src="https://github.com/user-attachments/assets/53993b9e-6d8f-44bf-91b9-70d789ea2fa8">  

<br>

  <img width="300" alt="" src="https://github.com/user-attachments/assets/ba68854e-65e8-4759-a2d0-a9fcb87d3063">  
  <img width="300" alt="" src="https://github.com/user-attachments/assets/9196647c-abdf-446b-85b6-9720b1f6d330">  
<br>
## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
