### PR TITLE
[Refactor] #47 카테고리 피드백 반영

### DIFF
--- a/UCDAppleStore/UCDAppleStore/Models/Category.swift
+++ b/UCDAppleStore/UCDAppleStore/Models/Category.swift
@@ -7,21 +7,6 @@ enum Category: String, Codable, CaseIterable {
     case mac = "Mac"
     case accessories = "Accessories"
 
-    var titleName: String {
-        switch self {
-        case .iphone:
-            return "iPhone"
-        case .ipad:
-            return "iPad"
-        case .macBook:
-            return "MacBook"
-        case .mac:
-            return "Mac"
-        case .accessories:
-            return "Accessories"
-        }
-    }
-
     static var allCategories: [Category] {
         return Category.allCases
     }

--- a/UCDAppleStore/UCDAppleStore/Models/Category.swift
+++ b/UCDAppleStore/UCDAppleStore/Models/Category.swift
@@ -6,8 +6,4 @@ enum Category: String, Codable, CaseIterable {
     case macBook = "MacBook"
     case mac = "Mac"
     case accessories = "Accessories"
-
-    static var allCategories: [Category] {
-        return Category.allCases
-    }
 }

--- a/UCDAppleStore/UCDAppleStore/ViewController/MainViewController.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewController/MainViewController.swift
@@ -18,15 +18,23 @@ class MainViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupViews()
         bindViewModels()
         loadInitialData()
+        setupViews()
         presentCartView()
     }
 
     // MARK: - Private Methods
 
     private func bindViewModels() {
+        categoryViewModel.onCategoriesLoaded = { [weak self] categories in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.categoryView.updateCategories(categories)
+                self.categoryView.updateUI(selectedCategory: self.categoryViewModel.selectedCategory)
+            }
+        }
+
         categoryViewModel.onCategoryChanged = { [weak self] category in
             DispatchQueue.main.async {
                 self?.categoryView.updateUI(selectedCategory: category)
@@ -55,6 +63,7 @@ class MainViewController: UIViewController {
     }
 
     private func loadInitialData() {
+        categoryViewModel.loadCategories()
         productViewModel.fetchProducts()
         productViewModel.filterProducts(by: categoryViewModel.selectedCategory)
     }
@@ -83,7 +92,6 @@ class MainViewController: UIViewController {
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(44)
         }
-        categoryView.updateUI(selectedCategory: categoryViewModel.selectedCategory)
     }
 
     private func setupProductListView() {

--- a/UCDAppleStore/UCDAppleStore/ViewModels/CategoryViewModel.swift
+++ b/UCDAppleStore/UCDAppleStore/ViewModels/CategoryViewModel.swift
@@ -3,13 +3,19 @@ import Foundation
 class CategoryViewModel {
     // MARK: - Properties
 
+    private(set) var categories: [Category] = Category.allCases
     private(set) var selectedCategory: Category = .iphone
 
     // MARK: - UI Update Closures
 
+    var onCategoriesLoaded: (([Category]) -> Void)?
     var onCategoryChanged: ((Category) -> Void)?
 
     // MARK: - Public Methods
+
+    func loadCategories() {
+        onCategoriesLoaded?(categories)
+    }
 
     func selectCategory(_ category: Category) {
         selectedCategory = category

--- a/UCDAppleStore/UCDAppleStore/Views/Category/CategoryView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/Category/CategoryView.swift
@@ -51,7 +51,6 @@ class CategoryView: UIView {
 
         stackView.snp.makeConstraints {
             $0.horizontalEdges.height.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(20)
         }
     }
 

--- a/UCDAppleStore/UCDAppleStore/Views/Category/CategoryView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/Category/CategoryView.swift
@@ -5,7 +5,7 @@ import UIKit
 class CategoryView: UIView {
     // MARK: - Properties
 
-    private var categories: [Category] = Category.allCategories
+    private var categories: [Category] = []
     private var categoryButtons: [UCDButton] = []
 
     weak var delegate: CategoryViewDelegate?
@@ -74,6 +74,11 @@ class CategoryView: UIView {
             categoryButtons.append(button)
             stackView.addArrangedSubview(button)
         }
+    }
+
+    func updateCategories(_ categories: [Category]) {
+        self.categories = categories
+        createCategoryButtons()
     }
 
     func updateUI(selectedCategory: Category) {

--- a/UCDAppleStore/UCDAppleStore/Views/Category/CategoryView.swift
+++ b/UCDAppleStore/UCDAppleStore/Views/Category/CategoryView.swift
@@ -63,7 +63,7 @@ class CategoryView: UIView {
 
         for (index, category) in categories.enumerated() {
             let button = UCDButton(style: .category).then {
-                $0.setTitle = category.titleName
+                $0.setTitle = category.rawValue
                 $0.tag = index
                 $0.addTarget(
                     self,


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #47 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- Category 열거형에서 필요하지 않은 titleName과 allCategories 삭제
- 기존: CategoryView가 Category.allCases를 직접 소유 -> ViewModel에서 데이터를 받아오는 구조로 변경

<br>

### ❌ 리팩토링 후 초기 화면에서 iPhone 버튼이 선택되지 않는 문제 발생
- 비동기 실행으로 인한 타이밍 이슈
  - 버튼 생성(updateCategories)과 선택 상태 설정(updateUI)이 분리됨
  - 선택 상태 설정이 버튼 생성보다 먼저 실행됨
- 해결 방법
  - 바인딩에서 버튼 생성 직후 초기 선택 상태 설정하도록 수정
<br>

